### PR TITLE
Bump JDA to 3.8.3_463 to support new channel types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ shadowJar {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "org.kitteh.irc:client-lib:5.1.2"
-    implementation("net.dv8tion:JDA:3.8.3_460") {
+    implementation("net.dv8tion:JDA:3.8.3_463") {
         exclude module: 'opus-java'
     }
 


### PR DESCRIPTION
Pls fix my commit message typo I did this in github web editor and I don't wanna be bothered 2 fix :c

I guess the new channel types in dumcord caused this bot to break on startup (even if the guild doesn't have said new channels...)

```
java.lang.IllegalArgumentException: Cannot create channel for type 5
	at net.dv8tion.jda.core.entities.EntityBuilder.createGuildChannel(EntityBuilder.java:251) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.entities.EntityBuilder.createGuild(EntityBuilder.java:211) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.handle.GuildSetupNode.completeSetup(GuildSetupNode.java:377) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.handle.GuildSetupNode.handleMemberChunk(GuildSetupNode.java:284) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.handle.GuildSetupController.onMemberChunk(GuildSetupController.java:235) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.handle.GuildMembersChunkHandler.handleInternally(GuildMembersChunkHandler.java:49) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.handle.SocketHandler.handle(SocketHandler.java:37) ~[Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.requests.WebSocketClient.onDispatch(WebSocketClient.java:868) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.requests.WebSocketClient.onEvent(WebSocketClient.java:766) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.requests.WebSocketClient.handleEvent(WebSocketClient.java:745) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at net.dv8tion.jda.core.requests.WebSocketClient.onBinaryMessage(WebSocketClient.java:903) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ListenerManager.callOnBinaryMessage(ListenerManager.java:368) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ReadingThread.callOnBinaryMessage(ReadingThread.java:270) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ReadingThread.handleBinaryFrame(ReadingThread.java:990) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:749) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
	at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45) [Dis4IRC-1.0.3-SNAPSHOT.jar:?]
```

A related issue I found when trying to debug this after taking a look at the JDA source code: https://github.com/jagrosh/MusicBot/issues/224

Edit: Ok, it seems I can't prevent github from automatically slapping a reference to other issues, even when I add it in an edit >_>