### PR TITLE
Permit bridging PMs (but poorly implemented)

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPier.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPier.kt
@@ -69,6 +69,12 @@ class IrcPier(private val bridge: Bridge) : Pier {
 
         // join all mapped channels
         for (mapping in bridge.config.channelMappings) {
+            if (mapping.ircChannel == "private-messages") {
+                ircConn.eventManager.registerEventListener(IrcPrivateListener(this))
+                logger.debug("Listening for private messages")
+                continue
+            }
+
             logger.debug("Joining ${mapping.ircChannel}")
             ircConn.addChannel(mapping.ircChannel)
         }

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPrivateListener.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPrivateListener.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Dis4IRC.
+ *
+ * Copyright (c) 2018-2019 Dis4IRC contributors
+ *
+ * MIT License
+ */
+
+package io.zachbr.dis4irc.bridge.pier.irc
+
+import io.zachbr.dis4irc.bridge.message.*
+import net.engio.mbassy.listener.Handler
+import org.kitteh.irc.client.library.event.user.PrivateMessageEvent
+import java.util.concurrent.TimeUnit
+
+class IrcPrivateListener(private val pier: IrcPier) {
+    private val logger = pier.logger
+    private var pmRatelimit = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+
+    @Handler
+    fun onPrivateMessage(event: PrivateMessageEvent) {
+        if (!event.isToClient) {
+            return
+        }
+
+        if (System.currentTimeMillis() > this.pmRatelimit) {
+            this.pmRatelimit = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5)
+            event.sendReply("I am a bot, and do not respond to PMs.")
+        }
+
+        val receiveTimestamp = System.nanoTime()
+        logger.debug("IRC PRIVATE MESSAGE FROM ${event.actor.name}")
+
+        val sender = Sender(event.actor.name, null, null)
+        val source = Source("private-messages", null, PlatformType.IRC)
+        val message = Message(event.message, sender, source, receiveTimestamp)
+        pier.sendToBridge(message)
+    }
+}


### PR DESCRIPTION
In case you also want to bridge PMs, I wrote this dirty hack to do it. It basically lets you map `private-messages` to a discord channel.

It builds on top of my other PR (#33) so that one should be handled first.

https://www.youtube.com/watch?v=-N0yXGVWS1Y

You can reject this PR if you don't like it and it doesn't maintain the code quality standards of what you'd like to have in the project, I don't really have any intention of fixing the implementation to be less hacky, as the purpose here is purely selfish.