### PR TITLE
Do log own quitting

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcJoinQuitListener.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcJoinQuitListener.kt
@@ -72,11 +72,6 @@ class IrcJoinQuitListener(private val pier: IrcPier) {
 
     @Handler
     fun onUserQuit(event: UserQuitEvent) {
-        // don't log our own quitting
-        if (event.user.nick == pier.getBotNick()) {
-            return
-        }
-
         val receiveTimestamp = System.nanoTime()
         val sender = BOT_SENDER
         val msgContent = "${event.user.nick} (${event.user.userString}@${event.user.host}) has quit"


### PR DESCRIPTION
Pretty arbitrary limit (up for debate), lets you see if something is wrong with the bot much earlier. Especially useful if reconnecting fails repeatedly (slightly relevant to #31)

Helped me detect such a problem much sooner:
![img](https://liefland.net/~zarthus/image/Discord_PlumesTasteful.png)