### PR TITLE
Update to KICL 7.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ shadowJar {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "org.kitteh.irc:client-lib:7.2.2"
+    implementation "org.kitteh.irc:client-lib:7.3.0"
     implementation("net.dv8tion:JDA:4.1.1_101") {
         exclude module: 'opus-java'
     }

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPier.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/IrcPier.kt
@@ -13,6 +13,7 @@ import io.zachbr.dis4irc.bridge.Bridge
 import io.zachbr.dis4irc.bridge.message.Message
 import io.zachbr.dis4irc.bridge.pier.Pier
 import org.kitteh.irc.client.library.Client
+import org.kitteh.irc.client.library.Client.Builder.Server.SecurityType
 import org.kitteh.irc.client.library.element.Channel
 import org.kitteh.irc.client.library.util.Format
 import org.slf4j.Logger
@@ -39,9 +40,8 @@ class IrcPier(private val bridge: Bridge) : Pier {
             .realName(bridge.config.irc.realName)
             .server()
                 .host(bridge.config.irc.hostname)
-                .port(bridge.config.irc.port)
+                .port(bridge.config.irc.port, if (bridge.config.irc.sslEnabled) SecurityType.SECURE else SecurityType.INSECURE)
                 .password(bridge.config.irc.password)
-                .secure(bridge.config.irc.sslEnabled)
 
         if (bridge.config.irc.allowInvalidCerts) {
             logger.warn("Allowing invalid TLS certificates for IRC. This is not recommended.")


### PR DESCRIPTION
KICL 7.3.0 comes with newer Netty and a fix for a reconnect bug. It also deprecates the previous port/secure methods in favor of a combined method. I have updated the dependency version and updated the method usage. I hope I got the Kotlin bit right, it's not really a language I have ever used but some brief searching suggested this was the proper solution.