### PR TITLE
Add a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=BUILD dis4irc.jar /srv/dis4irc.jar
 WORKDIR /srv
 
 # set the startup command
-CMD ["java", "-jar", "dis4irc.jar"]
+CMD ["java", "-jar", "dis4irc.jar", "-c", "config/config.hocon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,16 @@ RUN apk add git
 COPY ./ ./
 
 # build with gradle
-RUN ./gradlew build
+RUN ./gradlew build 
+
+# find the project version and copy the correct jar to the root
+RUN cp build/libs/Dis4IRC-$(./gradlew properties -q | grep "version:" | awk '{print $2}').jar dis4irc.jar
 
 # reset the container so we don't have source in the final build
 FROM adoptopenjdk/openjdk11:alpine
 
 # copy the jar
-COPY --from=BUILD /build/libs/Dis4IRC-*.jar /srv/dis4irc.jar
+COPY --from=BUILD dis4irc.jar /srv/dis4irc.jar
 
 # set the working dir
 WORKDIR /srv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# build stage
+FROM adoptopenjdk/openjdk11:alpine AS BUILD
+
+# install git
+RUN apk add git
+
+# copy source into the container
+COPY ./ ./
+
+# build with gradle
+RUN ./gradlew build
+
+# reset the container so we don't have source in the final build
+FROM adoptopenjdk/openjdk11:alpine
+
+# copy the jar
+COPY --from=BUILD /build/libs/Dis4IRC-*.jar /srv/dis4irc.jar
+
+# set the working dir
+WORKDIR /srv
+
+# set the startup command
+CMD ["java", "-jar", "dis4irc.jar"]


### PR DESCRIPTION
Adds a Dockerfile to allow running Dis4IRC in a Docker container. I'm more than happy to publish this on docker hub when it's finished.

To use, clone the repo,  `docker build .` then `docker run -v /path/to/dir/containing/config:/srv/config <container id>`.

Fixes #55 