### PR TITLE
Add option to show discriminator on IRC (Resolves #41)

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/ConfigurationData.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/ConfigurationData.kt
@@ -47,6 +47,7 @@ data class IrcConfiguration (
     val userName: String,
     val realName: String,
     val antiPing: Boolean,
+    val discriminator: Boolean,
     val noPrefixRegex: Pattern?,
     val announceForwardedCommands: Boolean,
     val discordReplyContextLimit: Int,
@@ -63,6 +64,7 @@ data class IrcConfiguration (
                 "userName='$userName', " +
                 "realName='$realName', " +
                 "antiPing=$antiPing, " +
+                "includeDiscriminator=$discriminator, " +
                 "noPrefixRegex=$noPrefixRegex, " +
                 "announceForwardedCommands=$announceForwardedCommands, " +
                 "discordReplyContextLimit=$discordReplyContextLimit, " +

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/message/Sender.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/message/Sender.kt
@@ -8,13 +8,17 @@
 
 package io.zachbr.dis4irc.bridge.message
 
-internal val BOT_SENDER = Sender("Bridge", null, null)
+internal val BOT_SENDER = Sender("Bridge", "Bridge", null, null)
 
 data class Sender(
     /**
      * User's display name, this is *not* guaranteed to be unique or secure
      */
     val displayName: String,
+    /**
+     * User's tag name, this is guaranteed to be unique
+     */
+    val tagName: String,
     /**
      * User's discord snowflake id, or null if the message originated from Discord
      */

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
@@ -102,7 +102,13 @@ class DiscordPier(private val bridge: Bridge) : Pier {
         val webhook = webhookMap[targetChan]
         val guild = channel.guild
 
-        // convert name use to proper mentions
+        // convert a user tag to proper mentions
+        for (member in guild.memberCache) {
+            val mentionTrigger = "@${member.user.asTag}" // require @ prefix
+            msg.contents = replaceTarget(msg.contents, mentionTrigger, member.asMention)
+        }
+
+        // convert effective nick name to proper mentions
         for (member in guild.memberCache) {
             val mentionTrigger = "@${member.effectiveName}" // require @ prefix
             msg.contents = replaceTarget(msg.contents, mentionTrigger, member.asMention)

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/Extensions.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/Extensions.kt
@@ -79,7 +79,7 @@ fun Message.toBridgeMsg(logger: Logger, receiveTimestamp: Long = System.nanoTime
     }
 
     val displayName = guildMember?.effectiveName ?: this.author.name // webhooks won't have an effective name
-    val tagName = guildMember?.user?.asTag ?: this.author.name // webhooks won't hav a tag
+    val tagName = guildMember?.user?.asTag ?: this.author.name // webhooks won't have a tag
     val sender = Sender(displayName, tagName, this.author.idLong, null)
     return io.zachbr.dis4irc.bridge.message.Message(
         messageText,

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/Extensions.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/Extensions.kt
@@ -79,7 +79,8 @@ fun Message.toBridgeMsg(logger: Logger, receiveTimestamp: Long = System.nanoTime
     }
 
     val displayName = guildMember?.effectiveName ?: this.author.name // webhooks won't have an effective name
-    val sender = Sender(displayName, this.author.idLong, null)
+    val tagName = guildMember?.user?.asTag ?: this.author.name // webhooks won't hav a tag
+    val sender = Sender(displayName, tagName, this.author.idLong, null)
     return io.zachbr.dis4irc.bridge.message.Message(
         messageText,
         sender,

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/Extensions.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/irc/Extensions.kt
@@ -16,5 +16,5 @@ import org.kitteh.irc.client.library.element.User
 import java.util.Optional
 
 fun Channel.asBridgeSource(): Source = Source(this.name, null, PlatformType.IRC)
-fun User.asBridgeSender(): Sender = Sender(this.nick, null, this.account.toNullable())
+fun User.asBridgeSender(): Sender = Sender(this.nick, this.realName.orElse(this.nick), null, this.account.toNullable())
 fun <T : Any> Optional<T>.toNullable(): T? = this.orElse(null)

--- a/src/main/kotlin/io/zachbr/dis4irc/config/ConfigurationUtils.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/config/ConfigurationUtils.kt
@@ -59,6 +59,10 @@ fun CommentedConfigurationNode.makeDefaultNode() {
     val ircAntiPing = ircBaseNode.node("anti-ping")
     ircAntiPing.set(true)
 
+    val ircDiscriminator = ircBaseNode.node("discriminator")
+    ircDiscriminator.set(true)
+    ircDiscriminator.comment("Include the discriminator or the full tag if a nickname is set")
+
     val announceForwards = ircBaseNode.node("announce-forwarded-messages-sender")
     announceForwards.set(false)
 
@@ -123,6 +127,7 @@ fun CommentedConfigurationNode.toBridgeConfiguration(): BridgeConfiguration {
     val ircUserName = getStringNonNull("IRC username cannot be null in $bridgeName!", "irc", "username")
     val ircRealName = getStringNonNull("IRC realname cannot be null in $bridgeName!", "irc", "realname")
     val ircAntiPing = this.node("irc", "anti-ping").boolean
+    val ircDiscriminator = this.node("irc", "discriminator").boolean
     val ircNoPrefix = this.node("irc", "no-prefix-regex").string // nullable
     val ircAnnounceForwards = this.node("irc", "announce-forwarded-messages-sender").boolean
     val ircDiscordReplyContextLimit = this.node("irc", "discord-reply-context-limit").int
@@ -190,7 +195,7 @@ fun CommentedConfigurationNode.toBridgeConfiguration(): BridgeConfiguration {
 
     val discordConfig = DiscordConfiguration(discordApiKey, webhookMappings)
     val ircConfig = IrcConfiguration(ircHost, ircPass, ircPort, ircUseSsl, ircAllowBadSsl, ircNickName, ircUserName,
-        ircRealName, ircAntiPing, ircNoPrefixPattern, ircAnnounceForwards, ircDiscordReplyContextLimit, ircCommandsList)
+        ircRealName, ircAntiPing, ircDiscriminator, ircNoPrefixPattern, ircAnnounceForwards, ircDiscordReplyContextLimit, ircCommandsList)
 
     return BridgeConfiguration(
         bridgeName,

--- a/src/test/kotlin/io/zachbr/dis4irc/bridge/message/MessageTest.kt
+++ b/src/test/kotlin/io/zachbr/dis4irc/bridge/message/MessageTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 class MessageTest {
     @Test
     fun testShouldSendTo() {
-        val sender = Sender("SomeSender", null, null)
+        val sender = Sender("SomeSender", "SomeSender#1234", null, null)
 
         // test from IRC
         val ircSource = Source("#some-channel", null, PlatformType.IRC)

--- a/src/test/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormattingTest.kt
+++ b/src/test/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormattingTest.kt
@@ -44,14 +44,14 @@ class TranslateFormattingTest {
     }
 
     private fun testIrcToDiscord(expected: String, string: String) {
-        val message = Message(string, Sender("Test", null, null), Source("#test", null, PlatformType.IRC), System.nanoTime())
+        val message = Message(string, Sender("Test", "Test", null, null), Source("#test", null, PlatformType.IRC), System.nanoTime())
         val mutator = TranslateFormatting()
         mutator.mutate(message)
         assertEquals(expected, message.contents)
     }
 
     private fun testDiscordToIrc(expected: String, input: String) {
-        val message = Message(input, Sender("Test", null, null), Source("#test", null, PlatformType.DISCORD), System.nanoTime())
+        val message = Message(input, Sender("Test", "Test#1234", null, null), Source("#test", null, PlatformType.DISCORD), System.nanoTime())
         val mutator = TranslateFormatting()
         mutator.mutate(message)
         assertEquals(expected, message.contents)


### PR DESCRIPTION
This will show the discriminator at the end of the name in dark gray if the display name matches the username and if not append the username + discriminator behind the nick name.

It also allows tagging of the username + discriminator combo.