### PR TITLE
Fix wrong pings due to partial matches

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
@@ -102,32 +102,13 @@ class DiscordPier(private val bridge: Bridge) : Pier {
         val webhook = webhookMap[targetChan]
         val guild = channel.guild
 
-        // convert name use to proper mentions
-        for (member in guild.memberCache) {
-            val mentionTrigger = "@${member.effectiveName}" // require @ prefix
-            msg.contents = replaceTarget(msg.contents, mentionTrigger, member.asMention)
-        }
-
-        // convert role use to proper mentions
-        for (role in guild.roleCache) {
-            if (!role.isMentionable) {
-                continue
-            }
-
-            val mentionTrigger = "@${role.name}" // require @ prefix
-            msg.contents = replaceTarget(msg.contents, mentionTrigger, role.asMention)
-        }
+        replaceMentions(guild, msg, true)
+        replaceMentions(guild, msg, false)
 
         // convert emotes to show properly
         for (emote in guild.emoteCache) {
             val mentionTrigger = ":${emote.name}:"
             msg.contents = replaceTarget(msg.contents, mentionTrigger, emote.asMention)
-        }
-
-        // convert text channels to mentions
-        for (guildChannel in guild.textChannelCache) {
-            val mentionTrigger = "#${guildChannel.name}"
-            msg.contents = replaceTarget(msg.contents, mentionTrigger, guildChannel.asMention)
         }
 
         // Discord won't broadcast messages that are just whitespace
@@ -143,6 +124,30 @@ class DiscordPier(private val bridge: Bridge) : Pier {
 
         val outTimestamp = System.nanoTime()
         bridge.updateStatistics(msg, outTimestamp)
+    }
+
+    private fun replaceMentions(guild: Guild, msg: Message, requireSeparation: Boolean) {
+        // convert name use to proper mentions
+        for (member in guild.memberCache) {
+            val mentionTrigger = "@${member.effectiveName}" // require @ prefix
+            msg.contents = replaceTarget(msg.contents, mentionTrigger, member.asMention, requireSeparation)
+        }
+
+        // convert role use to proper mentions
+        for (role in guild.roleCache) {
+            if (!role.isMentionable) {
+                continue
+            }
+
+            val mentionTrigger = "@${role.name}" // require @ prefix
+            msg.contents = replaceTarget(msg.contents, mentionTrigger, role.asMention, requireSeparation)
+        }
+
+        // convert text channels to mentions
+        for (guildChannel in guild.textChannelCache) {
+            val mentionTrigger = "#${guildChannel.name}"
+            msg.contents = replaceTarget(msg.contents, mentionTrigger, guildChannel.asMention, requireSeparation)
+        }
     }
 
     private fun sendMessageOldStyle(discordChannel: TextChannel, msg: Message) {

--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/pier/discord/DiscordPier.kt
@@ -102,7 +102,10 @@ class DiscordPier(private val bridge: Bridge) : Pier {
         val webhook = webhookMap[targetChan]
         val guild = channel.guild
 
+        // make sure to replace clearly separated mentions first to not replace partial mentions
         replaceMentions(guild, msg, true)
+
+        // replace mentions but don't require separation to find some previously missed, non-separated ones
         replaceMentions(guild, msg, false)
 
         // convert emotes to show properly


### PR DESCRIPTION
This fixes the issue that depending on the order of the member, role and channel list mentions might ping the wrong one e.g. `@phoenix616` could ping a user with the name `phoenix` if they are in the member list before `phoenix616` as the `StringUtil#replaceTarget` method is called with `requireSeparation = false` (which is fine if mentions that are followed by other characters like commas are meant to be replaced but it also means that wrong users might be matched).

This is done by first only checking for mentions that are separated by spaces/line endings and only after that trying the original, partial match to handle special cases that aren't easily distinguishable as user tags (e.g. commas after a ping).

While this is obviously less efficient than the original method I still believe that it can be more efficient than trying to actually determine a possible mention from the input string as that would mean searching through all users, roles and channels for every possible mention. Granted most messages might only include one mention so maybe a complete rework of how mentions are parsed could indeed be better in the long term but my approach is just a quicker fix for the underlying issue right now.

A completely different approach could be to sort the member/role/channel list by their tag string length in order to replace the longest first but I feel like that sorting could be even slower than this approach.