### PR TITLE
Fix stacked pings for users with numbers as names

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/util/StringUtil.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/util/StringUtil.kt
@@ -39,12 +39,16 @@ fun replaceTarget(base: CharSequence, target: String, replacement: CharSequence,
         return i == -1 || i == out.length || !requireSeparation || out[i].isWhitespace()
     }
 
+    fun isTarget(i: Int): Boolean {
+        return i > 0 && out[i - 1] == '<'
+    }
+
     var start = out.indexOf(target, 0)
     while (start > -1) {
         val end = start + target.length
         val nextSearchStart = start + replacement.length
 
-        if (isWhiteSpace(start - 1) && isWhiteSpace(end)) {
+        if (isWhiteSpace(start - 1) && isWhiteSpace(end) && !isTarget(start)) {
             out = out.replaceRange(start, start + target.length, replacement)
         }
 


### PR DESCRIPTION
This pull request attempts to fix #72. I tested it locally and it seems to solve the issue. Let me know if you want this to be solved differently.

To explain how it works: it stops replacing tags that are preceded by a `<` so that tags are not replaced multiple times.