### PR TITLE
Print markdown symbols in IRC for code blocks, bold, etc.

### DIFF
--- a/src/main/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormatting.kt
+++ b/src/main/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormatting.kt
@@ -131,9 +131,11 @@ class IrcRenderer(context: TextContentNodeRendererContext) : AbstractVisitor(), 
     }
 
     override fun visit(code: Code?) {
+        textContent.write("`")
         textContent.write(IrcFormattingCodes.MONOSPACE.char)
         textContent.write(code?.literal)
         textContent.write(IrcFormattingCodes.MONOSPACE.char)
+        textContent.write("`")
     }
 
     override fun visit(document: Document?) {
@@ -141,9 +143,11 @@ class IrcRenderer(context: TextContentNodeRendererContext) : AbstractVisitor(), 
     }
 
     override fun visit(emphasis: Emphasis?) {
+        textContent.write("*")
         textContent.write(IrcFormattingCodes.ITALICS.char)
         visitChildren(emphasis)
         textContent.write(IrcFormattingCodes.ITALICS.char)
+        textContent.write("*")
     }
 
     override fun visit(fencedCodeBlock: FencedCodeBlock?) {
@@ -213,14 +217,16 @@ class IrcRenderer(context: TextContentNodeRendererContext) : AbstractVisitor(), 
     }
 
     override fun visit(strongEmphasis: StrongEmphasis?) {
-        val wrapper: Char = when (strongEmphasis?.openingDelimiter) {
-            DiscordFormattingCodes.BOLD.code -> IrcFormattingCodes.BOLD.char
-            DiscordFormattingCodes.UNDERLINE.code -> IrcFormattingCodes.UNDERLINE.char
+        val (wrapper, marker) = when (strongEmphasis?.openingDelimiter) {
+            DiscordFormattingCodes.BOLD.code -> Pair(IrcFormattingCodes.BOLD.char, "**")
+            DiscordFormattingCodes.UNDERLINE.code -> Pair(IrcFormattingCodes.UNDERLINE.char, "__")
             else -> throw IllegalArgumentException("Unknown strong emphasis delimiter: ${strongEmphasis?.openingDelimiter}")
         }
+        textContent.write(marker)
         textContent.write(wrapper)
         visitChildren(strongEmphasis)
         textContent.write(wrapper)
+        textContent.write(marker)
     }
 
     override fun visit(text: Text?) {
@@ -229,9 +235,11 @@ class IrcRenderer(context: TextContentNodeRendererContext) : AbstractVisitor(), 
 
     override fun visit(customBlock: CustomBlock?) {
         if (customBlock is DiscordSpoiler) {
+            textContent.write("||")
             textContent.write(spoilerFormatCodeSequence)
             visitChildren(customBlock)
             textContent.write(IrcFormattingCodes.COLOR.char)
+            textContent.write("||")
         } else {
             throw IllegalArgumentException("Unknown custom block: $customBlock")
         }
@@ -239,9 +247,11 @@ class IrcRenderer(context: TextContentNodeRendererContext) : AbstractVisitor(), 
 
     override fun visit(customNode: CustomNode?) {
         if (customNode is Strikethrough) {
+            textContent.write("~~")
             textContent.write(IrcFormattingCodes.STRIKETHROUGH.char)
             visitChildren(customNode)
             textContent.write(IrcFormattingCodes.STRIKETHROUGH.char)
+            textContent.write("~~")
         } else {
             throw IllegalArgumentException("Unknown custom node: $customNode")
         }

--- a/src/test/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormattingTest.kt
+++ b/src/test/kotlin/io/zachbr/dis4irc/bridge/mutator/mutators/TranslateFormattingTest.kt
@@ -32,12 +32,12 @@ class TranslateFormattingTest {
 
     @Test
     fun discordToIrc() {
-        this.testDiscordToIrc("${Format.BOLD}Test bold${Format.BOLD}", "**Test bold**")
-        this.testDiscordToIrc("${Format.ITALIC}Test italics${Format.ITALIC}", "*Test italics*")
-        this.testDiscordToIrc("${Format.UNDERLINE}Test underlines${Format.UNDERLINE}", "__Test underlines__")
-        this.testDiscordToIrc("${IrcFormattingCodes.STRIKETHROUGH}Test strikethrough${IrcFormattingCodes.STRIKETHROUGH}", "~~Test strikethrough~~")
-        this.testDiscordToIrc("${Format.COLOR_CHAR}${IrcColorCodes.BLACK},${IrcColorCodes.BLACK}Test spoiler${Format.COLOR_CHAR}", "||Test spoiler||")
-        this.testDiscordToIrc("${IrcFormattingCodes.MONOSPACE}Test inline code${IrcFormattingCodes.MONOSPACE}", "`Test inline code`")
+        this.testDiscordToIrc("**${Format.BOLD}Test bold${Format.BOLD}**", "**Test bold**")
+        this.testDiscordToIrc("*${Format.ITALIC}Test italics${Format.ITALIC}*", "*Test italics*")
+        this.testDiscordToIrc("__${Format.UNDERLINE}Test underlines${Format.UNDERLINE}__", "__Test underlines__")
+        this.testDiscordToIrc("~~${IrcFormattingCodes.STRIKETHROUGH}Test strikethrough${IrcFormattingCodes.STRIKETHROUGH}~~", "~~Test strikethrough~~")
+        this.testDiscordToIrc("||${Format.COLOR_CHAR}${IrcColorCodes.BLACK},${IrcColorCodes.BLACK}Test spoiler${Format.COLOR_CHAR}||", "||Test spoiler||")
+        this.testDiscordToIrc("`${IrcFormattingCodes.MONOSPACE}Test inline code${IrcFormattingCodes.MONOSPACE}`", "`Test inline code`")
 
         //this.testDiscordToIrc("Attached${Format.COLOR_CHAR}${IrcColorCodes.BLACK},${IrcColorCodes.BLACK}together${Format.COLOR_CHAR}", "Attached||together||") // TODO - fix bug in case
         this.testDiscordToIrc("¯\\_(ツ)_/¯", "¯\\_(ツ)_/¯")


### PR DESCRIPTION
Ideally, this would be configured in the settings, but for now it is unconditional.

For this reason, I'll make this a draft PR, to be used by anybody who needs this. Feel free to take it as is if you feel like it, or I might improve it later.

-------------

In many IRC clients, including goguma/gamja/senpai (all the clients with good support for soju bouncers like <https://chat.sr.ht>), the formatting Dis4IRC previously used for this is invisible. For them, preserving the backticks, starts, etc, is very helpful.

Partially fixes #81